### PR TITLE
Update fieldset class in examples to the one preview is actually using (read-only-information page)

### DIFF
--- a/pages/preview/read-only-information.html
+++ b/pages/preview/read-only-information.html
@@ -80,7 +80,7 @@
 
 	<h4>Step 2: The fieldset</h4>
 	<p>What goes inside each of those grid columns is a fieldset. The fieldset gives us a nice title and a border around our information.</p>
-<pre class="language-markup"><code>&lt;fieldset class=&quot;read-only-information&quot;&gt;
+<pre class="language-markup"><code>&lt;fieldset class=&quot;flakes-information-box&quot;&gt;
 	&lt;legend&gt;Product Specs&lt;/legend&gt;
 &lt;/fieldset&gt;</code></pre>
 
@@ -111,7 +111,7 @@
 	<p>Might look a bit intimidating but it's just a mashup of a bunch of components. It's a grid with 2 columns. Each contain a fieldset. The first fieldset has a nested grid. And the definition lists hold the information.</p>
 <pre class="language-markup"><code>&lt;div class=&quot;grid-4 gutter-20&quot;&gt;
 	&lt;div class=&quot;span-3&quot;&gt;
-		&lt;fieldset class=&quot;read-only-information&quot;&gt;
+		&lt;fieldset class=&quot;flakes-information-box&quot;&gt;
 			&lt;legend&gt;Product Details&lt;/legend&gt;
 			&lt;div class=&quot;grid-4&quot;&gt;
 				&lt;dl class=&quot;span-2&quot;&gt;
@@ -140,7 +140,7 @@
 		&lt;/fieldset&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;span-1&quot;&gt;
-		&lt;fieldset class=&quot;read-only-information&quot;&gt;
+		&lt;fieldset class=&quot;flakes-information-box&quot;&gt;
 			&lt;legend&gt;Product Specs&lt;/legend&gt;
 			&lt;dl&gt;
 				&lt;dt&gt;SKU&lt;/dt&gt;


### PR DESCRIPTION
The page is built with the 'flakes-information-box' fieldset class, but the examples show 'read-only-information' which doesn't have any associated styling in CSS.  I'm new to flakes so I'm not sure if that was vestigial, but I had to look at the example source to get the right information so I figured I'd fix it and submit this PR.